### PR TITLE
Don't call sleep on first pass and skip URL requests if check_url=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Nova Galaxy 0.12.0 (in progress)
 
+### Nova Galaxy 0.11.1
+- Improved the performance of Job.get_url when check_url parameter is set to False (thanks to John Duggan). [Pull request 43](https://github.com/nova-model/nova-galaxy/pull/43)
 
 ### Nova Galaxy 0.11.0
 - Added detailed job status (thanks to Sergey Yakubov) [Pull request 40](https://github.com/nova-model/nova-galaxy/pull/40)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nova-galaxy"
-version = "0.11.0"
+version = "0.11.1"
 description = "Utilties for accessing the ORNL Galaxy instance"
 authors = ["Greg Watson <watsongr@ornl.gov>", "Gregory Cage <cagege@ornl.gov>", "Sergey Yakubov <yakubovs@ornl.gov>"]
 readme = "README.md"

--- a/src/nova/galaxy/job.py
+++ b/src/nova/galaxy/job.py
@@ -322,6 +322,8 @@ class Job:
             return self.url
         timer = max_tries
         while timer > 0:
+            if timer < max_tries:
+                time.sleep(1)
             try:
                 entry_points = self.galaxy_instance.make_get_request(
                     f"{self.store.nova_connection.galaxy_url}/api/entry_points?job_id={self.id}"
@@ -329,15 +331,19 @@ class Job:
                 for ep in entry_points.json():
                     if ep["job_id"] == self.id and ep.get("target", None):
                         url = f"{self.store.nova_connection.galaxy_url}{ep['target']}"
-                        self.url = url
+
+                        if not check_url:
+                            self.url = url
+                            return url
+
                         response = self.galaxy_instance.make_get_request(url)
-                        if response.status_code == 200 or not check_url:
+                        if response.status_code == 200:
+                            self.url = url
                             return url
             except Exception:
                 continue
             finally:
                 timer -= 1
-                time.sleep(1)
         return None
 
     def get_console_output(self, start: int, length: int) -> Dict[str, str]:


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
Skips the `time.sleep(1)` call on the first iteration of the loop. I've also made it skip querying the URL once if `check_url=False` and made it not store the URL until it's going to return the value.

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
