### PR TITLE
Check tool state before attempting to fetch URL for interactive tool

### DIFF
--- a/src/nova/galaxy/job.py
+++ b/src/nova/galaxy/job.py
@@ -322,6 +322,8 @@ class Job:
             return self.url
         timer = max_tries
         while timer > 0:
+            if self.get_state().state == WorkState.ERROR:
+                raise Exception("Could not fetch URL due to Tool Error.")
             if timer < max_tries:
                 time.sleep(1)
             try:


### PR DESCRIPTION
## Summary of Changes
Check tool state before attempting to fetch URL for interactive tool. Fixes bug (maybe not a bug per se, but improper behavior) where when a tool fails almost immediately, the get_url method would continue to check for the full timeout duration. 

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [ ] The PR has a clear and concise title
- [ ] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [ ] Automated tests are written and pass successfully.
- [ ] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [ ] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
