### PR TITLE
Workflow invocation improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nova-galaxy"
-version = "0.11.2"
+version = "0.11.3"
 description = "Utilties for accessing the ORNL Galaxy instance"
 authors = ["Greg Watson <watsongr@ornl.gov>", "Gregory Cage <cagege@ornl.gov>", "Sergey Yakubov <yakubovs@ornl.gov>"]
 readme = "README.md"

--- a/src/nova/galaxy/workflow.py
+++ b/src/nova/galaxy/workflow.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from .data_store import Datastore
 
 from bioblend import TimeoutException
+
 from nova.common.job import WorkState
 
 from .dataset import AbstractData, Dataset, DatasetCollection
@@ -170,19 +171,18 @@ class Invocation:
             self.status.details = f"Failed to prepare or submit workflow invocation: {str(e)}"
             self.invocation_id = None
 
-    def wait_for_results(self, max_tries=120) -> None:
+    def wait_for_results(self, max_tries: float = 120) -> None:
         """Waits for the workflow invocation to complete."""
         if not self.invocation_id:
             raise Exception("Cannot wait for results, invocation ID is not set.")
-
 
         # galaxy doesn't always return when a job fails. Periodically checking the jobs to see if we should return.
         attempt_counter = 0
         while True:
             try:
                 if attempt_counter < max_tries:
-                    self.galaxy_instance.invocations.wait_for_invocation(self.invocation_id, maxwait = 5)
-            except TimeoutException as e:
+                    self.galaxy_instance.invocations.wait_for_invocation(self.invocation_id, maxwait=5)
+            except TimeoutException:
                 # check if any steps failed. If they have we return. Otherwise we just wait some more.
                 attempt_counter += 1
                 for step in self.get_step_jobs(running_only=False):

--- a/src/nova/galaxy/workflow.py
+++ b/src/nova/galaxy/workflow.py
@@ -178,11 +178,10 @@ class Invocation:
 
         # galaxy doesn't always return when a job fails. Periodically checking the jobs to see if we should return.
         attempt_counter = 0
-        while True:
+        while attempt_counter < max_tries:
             try:
-                if attempt_counter < max_tries:
-                    self.galaxy_instance.invocations.wait_for_invocation(self.invocation_id, maxwait=5)
-                    break
+                self.galaxy_instance.invocations.wait_for_invocation(self.invocation_id, maxwait=5)
+                break
             except TimeoutException:
                 # check if any steps failed. If they have we return. Otherwise we just wait some more.
                 attempt_counter += 1

--- a/src/nova/galaxy/workflow.py
+++ b/src/nova/galaxy/workflow.py
@@ -171,16 +171,17 @@ class Invocation:
             self.status.details = f"Failed to prepare or submit workflow invocation: {str(e)}"
             self.invocation_id = None
 
-    def wait_for_results(self, max_tries: float = 120) -> None:
+    def wait_for_results(self, max_tries: int | None = None) -> None:
         """Waits for the workflow invocation to complete."""
         if not self.invocation_id:
             raise Exception("Cannot wait for results, invocation ID is not set.")
 
         # galaxy doesn't always return when a job fails. Periodically checking the jobs to see if we should return.
         attempt_counter = 0
-        while attempt_counter < max_tries:
+        while True:
             try:
-                self.galaxy_instance.invocations.wait_for_invocation(self.invocation_id, maxwait=5)
+                if max_tries is None or attempt_counter < max_tries:
+                    self.galaxy_instance.invocations.wait_for_invocation(self.invocation_id, maxwait=5)
                 break
             except TimeoutException:
                 # check if any steps failed. If they have we return. Otherwise we just wait some more.

--- a/src/nova/galaxy/workflow.py
+++ b/src/nova/galaxy/workflow.py
@@ -182,6 +182,7 @@ class Invocation:
             try:
                 if attempt_counter < max_tries:
                     self.galaxy_instance.invocations.wait_for_invocation(self.invocation_id, maxwait=5)
+                    break
             except TimeoutException:
                 # check if any steps failed. If they have we return. Otherwise we just wait some more.
                 attempt_counter += 1
@@ -193,7 +194,7 @@ class Invocation:
         # galaxy returns once all steps are scheduled instead of complete. Need to wait for each job to complete
         for step in self.get_step_jobs():
             if step._job is not None:
-                step._job.wait_for_results(running_only=False)
+                step._job.wait_for_results()
                 if step.get_status() is not WorkState.FINISHED:
                     return
 

--- a/src/nova/galaxy/workflow.py
+++ b/src/nova/galaxy/workflow.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 if TYPE_CHECKING:
     from .data_store import Datastore
 
+from bioblend import TimeoutException
 from nova.common.job import WorkState
 
 from .dataset import AbstractData, Dataset, DatasetCollection
@@ -169,16 +170,30 @@ class Invocation:
             self.status.details = f"Failed to prepare or submit workflow invocation: {str(e)}"
             self.invocation_id = None
 
-    def wait_for_results(self) -> None:
+    def wait_for_results(self, max_tries=120) -> None:
         """Waits for the workflow invocation to complete."""
         if not self.invocation_id:
             raise Exception("Cannot wait for results, invocation ID is not set.")
 
+
+        # galaxy doesn't always return when a job fails. Periodically checking the jobs to see if we should return.
+        attempt_counter = 0
+        while True:
+            try:
+                if attempt_counter < max_tries:
+                    self.galaxy_instance.invocations.wait_for_invocation(self.invocation_id, maxwait = 5)
+            except TimeoutException as e:
+                # check if any steps failed. If they have we return. Otherwise we just wait some more.
+                attempt_counter += 1
+                for step in self.get_step_jobs(running_only=False):
+                    if step._job is not None:
+                        if step.get_status() is WorkState.ERROR:
+                            return
+
         # galaxy returns once all steps are scheduled instead of complete. Need to wait for each job to complete
-        self.galaxy_instance.invocations.wait_for_invocation(self.invocation_id)
         for step in self.get_step_jobs():
             if step._job is not None:
-                step._job.wait_for_results()
+                step._job.wait_for_results(running_only=False)
                 if step.get_status() is not WorkState.FINISHED:
                     return
 
@@ -271,7 +286,7 @@ class Invocation:
         """Returns the Galaxy invocation ID."""
         return self.invocation_id
 
-    def get_step_jobs(self) -> List[Tool]:
+    def get_step_jobs(self, running_only: bool = True) -> List[Tool]:
         """Returns nova-galaxy Job instances for each step in the workflow invocation."""
         if not self.invocation_id:
             return []
@@ -279,8 +294,7 @@ class Invocation:
         try:
             jobs_summary = self.galaxy_instance.invocations.get_invocation_step_jobs_summary(self.invocation_id)
             step_jobs = []
-
-            tools = self.store.recover_tools(filter_running=True)
+            tools = self.store.recover_tools(filter_running=running_only)
 
             for job_info in jobs_summary:
                 if job_info.get("id"):
@@ -446,11 +460,17 @@ class Workflow(AbstractWorkflow):
             return self._invocation.get_invocation_id()
         return None
 
-    def get_step_jobs(self) -> List[Tool]:
+    def get_step_jobs(self, running_only: bool = True) -> List[Tool]:
         """Gets nova-galaxy Job instances for each step in the workflow.
 
         Returns the individual jobs that make up the workflow steps,
         allowing access to step-level status, outputs, and console logs.
+
+        Parameters
+        ----------
+        running_only : Optional[bool]
+            A boolean that determines whether or not to return only jobs which
+           are currently running.
 
         Returns
         -------
@@ -470,7 +490,7 @@ class Workflow(AbstractWorkflow):
         ...         print(console.get('stdout', ''))
         """
         if self._invocation:
-            return self._invocation.get_step_jobs()
+            return self._invocation.get_step_jobs(running_only)
         return []
 
     def get_step_name(self, step_number: int) -> str:


### PR DESCRIPTION
## Summary of Changes
Main changes here:
* added option when getting workflow jobs of whether or not filter only running jobs. Previously, we always filtered down to running jobs.
* improved the wait_for_results method. Due to some quirks with galaxy, the call to galaxy would sometimes hang if the workflow had an error. The result is this wouldn't return until the default timeout which was quite long (30 minutes or so). Changed it so that we periodically check if it's in a terminal state. If not we check the state of the jobs to look for an error. If we find one we return.  
## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [ ] The PR has a clear and concise title
- [ ] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [ ] Automated tests are written and pass successfully.
- [ ] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [ ] Readme file is present and up-to-date.
